### PR TITLE
Normalize sassRoot without a trailing slash

### DIFF
--- a/lib/sassGlobber.js
+++ b/lib/sassGlobber.js
@@ -17,6 +17,7 @@ var SassGlobbing = function (obj) {
 	};
 
 	this.options = Helpers.extend(this.options, obj);
+	this.options.sassRoot = this.options.sassRoot.replace(/\/$/, "");
 	this.source = this.options.sassRoot + '/' + this.options.source;
 	this.output = this.options.sassRoot + '/' + this.options.output;
 


### PR DESCRIPTION
Much of the code assumes `sassRoot` does not contain a trailing slash.

Specifically, `SassGlobbing.prototype.getImports()` will fail to remove the sassRoot from the output when a trailing slash is present.

This PR removes the trailing slash when processing options.